### PR TITLE
UnicodeDecodeError while installing module fixed 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import setuptools
 HERE = pathlib.Path(__file__).parent
 
 # The text of the README file
-README = (HERE / "README.md").read_text()
+README = (HERE / "README.md").read_text(encoding="utf-8")
 
 setuptools.setup(
     name="a2",


### PR DESCRIPTION
An issue in setup.py Line 8 which led to 

UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 683: character maps to <undefined>

Fixed by adding encoding utf-8